### PR TITLE
add option `tipr.verbose` with default `TRUE`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Description: The strength of evidence provided by epidemiological and observatio
             may tip our result to insignificance.
 License: MIT + file LICENSE
 Encoding: UTF-8
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Roxygen: list(markdown = TRUE)
 BugReports: https://github.com/LucyMcGowan/tipr/issues
 Suggests:

--- a/R/adjust_coef_with_r2.R
+++ b/R/adjust_coef_with_r2.R
@@ -37,7 +37,7 @@ adjust_coef_with_r2 <- function(effect_observed,
                                 df,
                                 confounder_exposure_r2,
                                 confounder_outcome_r2,
-                                verbose = TRUE,
+                                verbose = getOption("tipr.verbose", TRUE),
                                 alpha = 0.05,
                                 ...) {
   effect_adjusted <- sensemakr::adjusted_estimate(

--- a/R/adjust_coefficient.R
+++ b/R/adjust_coefficient.R
@@ -24,7 +24,7 @@ adjust_coef <-
   function(effect_observed,
            exposure_confounder_effect,
            confounder_outcome_effect,
-           verbose = TRUE) {
+           verbose = getOption("tipr.verbose", TRUE)) {
     effect_adj <-
       effect_observed - confounder_outcome_effect * exposure_confounder_effect
     o <- tibble::tibble(
@@ -71,7 +71,7 @@ adjust_coef_with_binary <-
            exposed_confounder_prev,
            unexposed_confounder_prev,
            confounder_outcome_effect,
-           verbose = TRUE) {
+           verbose = getOption("tipr.verbose", TRUE)) {
     check_prevalences(unexposed_confounder_prev, exposed_confounder_prev)
 
     confounding_factor <- log((exp(confounder_outcome_effect) * exposed_confounder_prev + (1 - exposed_confounder_prev)) /
@@ -176,7 +176,7 @@ adjust_hr <-
   function(effect_observed,
            exposure_confounder_effect,
            confounder_outcome_effect,
-           verbose = TRUE,
+           verbose = getOption("tipr.verbose", TRUE),
            hr_correction = FALSE) {
     hr <- effect_observed
     if (hr_correction) {
@@ -241,7 +241,7 @@ adjust_or <-
   function(effect_observed,
            exposure_confounder_effect,
            confounder_outcome_effect,
-           verbose = TRUE,
+           verbose = getOption("tipr.verbose", TRUE),
            or_correction = FALSE) {
     or <- effect_observed
     if (or_correction) {
@@ -302,7 +302,7 @@ adjust_rr_with_binary <-
            exposed_confounder_prev,
            unexposed_confounder_prev,
            confounder_outcome_effect,
-           verbose = TRUE) {
+           verbose = getOption("tipr.verbose", TRUE)) {
     rr <- effect_observed
     check_prevalences(unexposed_confounder_prev, exposed_confounder_prev)
 
@@ -361,7 +361,7 @@ adjust_hr_with_binary <-
            exposed_confounder_prev,
            unexposed_confounder_prev,
            confounder_outcome_effect,
-           verbose = TRUE,
+           verbose = getOption("tipr.verbose", TRUE),
            hr_correction = FALSE) {
     hr <- effect_observed
     if (hr_correction) {
@@ -431,7 +431,7 @@ adjust_or_with_binary <-
            exposed_confounder_prev,
            unexposed_confounder_prev,
            confounder_outcome_effect,
-           verbose = TRUE,
+           verbose = getOption("tipr.verbose", TRUE),
            or_correction = FALSE) {
     or <- effect_observed
     if (or_correction) {

--- a/R/tip.R
+++ b/R/tip.R
@@ -45,7 +45,7 @@
 #'}
 #' @export
 tip <- function(effect_observed, exposure_confounder_effect = NULL, confounder_outcome_effect = NULL,
-                verbose = TRUE, correction_factor = "none") {
+                verbose = getOption("tipr.verbose", TRUE), correction_factor = "none") {
 
   exposure_confounder_effect <- exposure_confounder_effect %||% list(NULL)
   confounder_outcome_effect <- confounder_outcome_effect %||% list(NULL)
@@ -212,7 +212,7 @@ tip_one <- function(b, exposure_confounder_effect, confounder_outcome_effect, ve
 #' tip_rr(1.2, exposure_confounder_effect = -2, confounder_outcome_effect = .99)
 #'
 #' @export
-tip_rr <- function(effect_observed, exposure_confounder_effect = NULL, confounder_outcome_effect = NULL, verbose = TRUE) {
+tip_rr <- function(effect_observed, exposure_confounder_effect = NULL, confounder_outcome_effect = NULL, verbose = getOption("tipr.verbose", TRUE)) {
   tip(effect_observed, exposure_confounder_effect = exposure_confounder_effect, confounder_outcome_effect = confounder_outcome_effect, verbose = verbose)
 }
 
@@ -250,7 +250,7 @@ tip_rr <- function(effect_observed, exposure_confounder_effect = NULL, confounde
 #' tip_hr(1.2, exposure_confounder_effect = -2, confounder_outcome_effect = .99)
 #'
 #' @export
-tip_hr <- function(effect_observed, exposure_confounder_effect = NULL, confounder_outcome_effect = NULL, verbose = TRUE, hr_correction = FALSE) {
+tip_hr <- function(effect_observed, exposure_confounder_effect = NULL, confounder_outcome_effect = NULL, verbose = getOption("tipr.verbose", TRUE), hr_correction = FALSE) {
   correction_factor <- ifelse(hr_correction, "hr", "none")
   tip(effect_observed, exposure_confounder_effect = exposure_confounder_effect, confounder_outcome_effect = confounder_outcome_effect, verbose = verbose, correction_factor = correction_factor)
 }
@@ -297,7 +297,7 @@ tip_hr <- function(effect_observed, exposure_confounder_effect = NULL, confounde
 #'    tip_or(confounder_outcome_effect = 2.5, or_correction = TRUE)
 #'}
 #' @export
-tip_or <- function(effect_observed, exposure_confounder_effect = NULL, confounder_outcome_effect = NULL, verbose = TRUE, or_correction = FALSE) {
+tip_or <- function(effect_observed, exposure_confounder_effect = NULL, confounder_outcome_effect = NULL, verbose = getOption("tipr.verbose", TRUE), or_correction = FALSE) {
   correction_factor <- ifelse(or_correction, "or", "none")
   tip(effect_observed, exposure_confounder_effect = exposure_confounder_effect, confounder_outcome_effect = confounder_outcome_effect, verbose = verbose, correction_factor = correction_factor)
 }

--- a/R/tip_coef.R
+++ b/R/tip_coef.R
@@ -37,7 +37,7 @@
 #'    tip_coef(confounder_outcome_effect = 2.5)
 #'}
 #' @export
-tip_coef <- function(effect_observed, exposure_confounder_effect = NULL, confounder_outcome_effect = NULL, verbose = TRUE) {
+tip_coef <- function(effect_observed, exposure_confounder_effect = NULL, confounder_outcome_effect = NULL, verbose = getOption("tipr.verbose", TRUE)) {
 
   o <- purrr::map(
     effect_observed,

--- a/R/tip_coef_with_r2.R
+++ b/R/tip_coef_with_r2.R
@@ -35,7 +35,7 @@ tip_coef_with_r2 <- function(effect_observed,
                              df,
                              confounder_exposure_r2 = NULL,
                              confounder_outcome_r2 = NULL,
-                             verbose = TRUE,
+                             verbose = getOption("tipr.verbose", TRUE),
                              alpha = 0.05,
                              tip_bound = FALSE,
                              ...) {

--- a/R/tip_with_binary.R
+++ b/R/tip_with_binary.R
@@ -56,7 +56,7 @@ tip_with_binary <- function(effect_observed,
                             exposed_confounder_prev = NULL,
                             unexposed_confounder_prev = NULL,
                             confounder_outcome_effect = NULL,
-                            verbose = TRUE,
+                            verbose = getOption("tipr.verbose", TRUE),
                             correction_factor = "none") {
   exposed_confounder_prev <- exposed_confounder_prev %||% list(NULL)
   unexposed_confounder_prev <- unexposed_confounder_prev %||% list(NULL)
@@ -243,7 +243,7 @@ tip_with_binary_one <- function(b,
 #' @param verbose Logical. Indicates whether to print informative message.
 #'    Default: `TRUE`
 
-tip_rr_with_binary <- function(effect_observed, exposed_confounder_prev = NULL, unexposed_confounder_prev = NULL, confounder_outcome_effect = NULL, verbose = TRUE) {
+tip_rr_with_binary <- function(effect_observed, exposed_confounder_prev = NULL, unexposed_confounder_prev = NULL, confounder_outcome_effect = NULL, verbose = getOption("tipr.verbose", TRUE)) {
   tip_with_binary(effect_observed, exposed_confounder_prev = exposed_confounder_prev, unexposed_confounder_prev = unexposed_confounder_prev, confounder_outcome_effect = confounder_outcome_effect, verbose = verbose)
 }
 
@@ -280,7 +280,7 @@ tip_rr_with_binary <- function(effect_observed, exposed_confounder_prev = NULL, 
 #' @examples
 #' tip_hr_with_binary(0.9, 0.9, 0.1)
 
-tip_hr_with_binary <- function(effect_observed, exposed_confounder_prev = NULL, unexposed_confounder_prev = NULL, confounder_outcome_effect = NULL, verbose = TRUE, hr_correction = FALSE) {
+tip_hr_with_binary <- function(effect_observed, exposed_confounder_prev = NULL, unexposed_confounder_prev = NULL, confounder_outcome_effect = NULL, verbose = getOption("tipr.verbose", TRUE), hr_correction = FALSE) {
   correction_factor <- ifelse(hr_correction, "hr", "none")
   tip_with_binary(effect_observed, exposed_confounder_prev = exposed_confounder_prev, unexposed_confounder_prev = unexposed_confounder_prev, confounder_outcome_effect = confounder_outcome_effect, verbose = verbose, correction_factor = correction_factor)
 }
@@ -318,7 +318,7 @@ tip_hr_with_binary <- function(effect_observed, exposed_confounder_prev = NULL, 
 #' @examples
 #' tip_or_with_binary(0.9, 0.9, 0.1)
 
-tip_or_with_binary <- function(effect_observed, exposed_confounder_prev = NULL, unexposed_confounder_prev = NULL, confounder_outcome_effect = NULL, verbose = TRUE, or_correction = FALSE) {
+tip_or_with_binary <- function(effect_observed, exposed_confounder_prev = NULL, unexposed_confounder_prev = NULL, confounder_outcome_effect = NULL, verbose = getOption("tipr.verbose", TRUE), or_correction = FALSE) {
   correction_factor <- ifelse(or_correction, "or", "none")
   tip_with_binary(effect_observed, exposed_confounder_prev = exposed_confounder_prev, unexposed_confounder_prev = unexposed_confounder_prev, confounder_outcome_effect = confounder_outcome_effect, verbose = verbose, correction_factor = correction_factor)
 }

--- a/man/adjust_coef.Rd
+++ b/man/adjust_coef.Rd
@@ -10,14 +10,14 @@ adjust_coef(
   effect_observed,
   exposure_confounder_effect,
   confounder_outcome_effect,
-  verbose = TRUE
+  verbose = getOption("tipr.verbose", TRUE)
 )
 
 adjust_coef_with_continuous(
   effect_observed,
   exposure_confounder_effect,
   confounder_outcome_effect,
-  verbose = TRUE
+  verbose = getOption("tipr.verbose", TRUE)
 )
 }
 \arguments{

--- a/man/adjust_coef_with_binary.Rd
+++ b/man/adjust_coef_with_binary.Rd
@@ -9,7 +9,7 @@ adjust_coef_with_binary(
   exposed_confounder_prev,
   unexposed_confounder_prev,
   confounder_outcome_effect,
-  verbose = TRUE
+  verbose = getOption("tipr.verbose", TRUE)
 )
 }
 \arguments{

--- a/man/adjust_coef_with_r2.Rd
+++ b/man/adjust_coef_with_r2.Rd
@@ -12,7 +12,7 @@ adjust_coef_with_r2(
   df,
   confounder_exposure_r2,
   confounder_outcome_r2,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   alpha = 0.05,
   ...
 )

--- a/man/adjust_hr.Rd
+++ b/man/adjust_hr.Rd
@@ -10,7 +10,7 @@ adjust_hr(
   effect_observed,
   exposure_confounder_effect,
   confounder_outcome_effect,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   hr_correction = FALSE
 )
 
@@ -18,7 +18,7 @@ adjust_hr_with_continuous(
   effect_observed,
   exposure_confounder_effect,
   confounder_outcome_effect,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   hr_correction = FALSE
 )
 }

--- a/man/adjust_hr_with_binary.Rd
+++ b/man/adjust_hr_with_binary.Rd
@@ -9,7 +9,7 @@ adjust_hr_with_binary(
   exposed_confounder_prev,
   unexposed_confounder_prev,
   confounder_outcome_effect,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   hr_correction = FALSE
 )
 }

--- a/man/adjust_or.Rd
+++ b/man/adjust_or.Rd
@@ -10,7 +10,7 @@ adjust_or(
   effect_observed,
   exposure_confounder_effect,
   confounder_outcome_effect,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   or_correction = FALSE
 )
 
@@ -18,7 +18,7 @@ adjust_or_with_continuous(
   effect_observed,
   exposure_confounder_effect,
   confounder_outcome_effect,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   or_correction = FALSE
 )
 }

--- a/man/adjust_or_with_binary.Rd
+++ b/man/adjust_or_with_binary.Rd
@@ -9,7 +9,7 @@ adjust_or_with_binary(
   exposed_confounder_prev,
   unexposed_confounder_prev,
   confounder_outcome_effect,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   or_correction = FALSE
 )
 }

--- a/man/adjust_rr_with_binary.Rd
+++ b/man/adjust_rr_with_binary.Rd
@@ -9,7 +9,7 @@ adjust_rr_with_binary(
   exposed_confounder_prev,
   unexposed_confounder_prev,
   confounder_outcome_effect,
-  verbose = TRUE
+  verbose = getOption("tipr.verbose", TRUE)
 )
 }
 \arguments{

--- a/man/tip.Rd
+++ b/man/tip.Rd
@@ -10,7 +10,7 @@ tip(
   effect_observed,
   exposure_confounder_effect = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   correction_factor = "none"
 )
 
@@ -18,7 +18,7 @@ tip_with_continuous(
   effect_observed,
   exposure_confounder_effect = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   correction_factor = "none"
 )
 
@@ -26,7 +26,7 @@ tip_c(
   effect_observed,
   exposure_confounder_effect = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   correction_factor = "none"
 )
 }

--- a/man/tip_coef.Rd
+++ b/man/tip_coef.Rd
@@ -9,14 +9,14 @@ tip_coef(
   effect_observed,
   exposure_confounder_effect = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE
+  verbose = getOption("tipr.verbose", TRUE)
 )
 
 tip_coef_with_continuous(
   effect_observed,
   exposure_confounder_effect = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE
+  verbose = getOption("tipr.verbose", TRUE)
 )
 }
 \arguments{

--- a/man/tip_coef_with_r2.Rd
+++ b/man/tip_coef_with_r2.Rd
@@ -12,7 +12,7 @@ tip_coef_with_r2(
   df,
   confounder_exposure_r2 = NULL,
   confounder_outcome_r2 = NULL,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   alpha = 0.05,
   tip_bound = FALSE,
   ...

--- a/man/tip_hr.Rd
+++ b/man/tip_hr.Rd
@@ -9,7 +9,7 @@ tip_hr(
   effect_observed,
   exposure_confounder_effect = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   hr_correction = FALSE
 )
 
@@ -17,7 +17,7 @@ tip_hr_with_continuous(
   effect_observed,
   exposure_confounder_effect = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   hr_correction = FALSE
 )
 }

--- a/man/tip_hr_with_binary.Rd
+++ b/man/tip_hr_with_binary.Rd
@@ -9,7 +9,7 @@ tip_hr_with_binary(
   exposed_confounder_prev = NULL,
   unexposed_confounder_prev = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   hr_correction = FALSE
 )
 }

--- a/man/tip_or.Rd
+++ b/man/tip_or.Rd
@@ -9,7 +9,7 @@ tip_or(
   effect_observed,
   exposure_confounder_effect = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   or_correction = FALSE
 )
 
@@ -17,7 +17,7 @@ tip_or_with_continuous(
   effect_observed,
   exposure_confounder_effect = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   or_correction = FALSE
 )
 }

--- a/man/tip_or_with_binary.Rd
+++ b/man/tip_or_with_binary.Rd
@@ -9,7 +9,7 @@ tip_or_with_binary(
   exposed_confounder_prev = NULL,
   unexposed_confounder_prev = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   or_correction = FALSE
 )
 }

--- a/man/tip_rr.Rd
+++ b/man/tip_rr.Rd
@@ -9,14 +9,14 @@ tip_rr(
   effect_observed,
   exposure_confounder_effect = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE
+  verbose = getOption("tipr.verbose", TRUE)
 )
 
 tip_rr_with_continuous(
   effect_observed,
   exposure_confounder_effect = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE
+  verbose = getOption("tipr.verbose", TRUE)
 )
 }
 \arguments{

--- a/man/tip_rr_with_binary.Rd
+++ b/man/tip_rr_with_binary.Rd
@@ -9,7 +9,7 @@ tip_rr_with_binary(
   exposed_confounder_prev = NULL,
   unexposed_confounder_prev = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE
+  verbose = getOption("tipr.verbose", TRUE)
 )
 }
 \arguments{

--- a/man/tip_with_binary.Rd
+++ b/man/tip_with_binary.Rd
@@ -10,7 +10,7 @@ tip_with_binary(
   exposed_confounder_prev = NULL,
   unexposed_confounder_prev = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   correction_factor = "none"
 )
 
@@ -19,7 +19,7 @@ tip_b(
   exposed_confounder_prev = NULL,
   unexposed_confounder_prev = NULL,
   confounder_outcome_effect = NULL,
-  verbose = TRUE,
+  verbose = getOption("tipr.verbose", TRUE),
   correction_factor = "none"
 )
 }


### PR DESCRIPTION
This PR changes the default of `verbose` to use `getOption("tipr.verbose", TRUE)`. For most users, the default of `verbose` will remain `TRUE`. My goal here is to easily disable verbosity in settings like the book with `options(tipr.verbose = FALSE)`