### PR TITLE
Overhaul messaging and erroring

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
-Package: tipr
 Type: Package
+Package: tipr
 Title: Tipping Point Analyses
 Version: 1.0.1.9000
 Authors@R: c(
@@ -8,36 +8,38 @@ Authors@R: c(
     person("Malcolm", "Barrett", , "malcolmbarrett@gmail.com", role = "ctb",
            comment = c(ORCID = "0000-0003-0299-5825"))
   )
-Description: The strength of evidence provided by epidemiological and observational 
-            studies is inherently limited by the potential for unmeasured confounding. 
-            We focus on three key quantities: the observed bound of the confidence 
-            interval closest to the null, the relationship between an unmeasured 
-            confounder and the outcome, for example a plausible residual effect 
-            size for an unmeasured continuous or binary confounder, and the 
-            relationship between an unmeasured confounder and the exposure, 
-            for example a realistic mean difference or prevalence difference 
-            for this hypothetical confounder between exposure groups. Building 
-            on the methods put forth by Cornfield et al. (1959), Bross (1966), 
-            Schlesselman (1978), Rosenbaum & Rubin (1983), Lin et al. (1998), 
-            Lash et al. (2009), Rosenbaum (1986), Cinelli & Hazlett (2020), 
-            VanderWeele & Ding (2017), and Ding & VanderWeele (2016), 
-            we can use these quantities to assess how an unmeasured confounder
-            may tip our result to insignificance.
+Description: The strength of evidence provided by epidemiological and
+    observational studies is inherently limited by the potential for
+    unmeasured confounding.  We focus on three key quantities: the
+    observed bound of the confidence interval closest to the null, the
+    relationship between an unmeasured confounder and the outcome, for
+    example a plausible residual effect size for an unmeasured continuous
+    or binary confounder, and the relationship between an unmeasured
+    confounder and the exposure, for example a realistic mean difference
+    or prevalence difference for this hypothetical confounder between
+    exposure groups. Building on the methods put forth by Cornfield et al.
+    (1959), Bross (1966), Schlesselman (1978), Rosenbaum & Rubin (1983),
+    Lin et al. (1998), Lash et al. (2009), Rosenbaum (1986), Cinelli &
+    Hazlett (2020), VanderWeele & Ding (2017), and Ding & VanderWeele
+    (2016), we can use these quantities to assess how an unmeasured
+    confounder may tip our result to insignificance.
 License: MIT + file LICENSE
-Encoding: UTF-8
-RoxygenNote: 7.2.1
-Roxygen: list(markdown = TRUE)
 BugReports: https://github.com/LucyMcGowan/tipr/issues
-Suggests:
-    testthat,
-    broom,
-    dplyr,
-    MASS
-Imports:
-    glue,
-    tibble,
-    purrr,
-    sensemakr
 Depends: 
     R (>= 2.10)
+Imports:
+    cli (>= 3.4.1),
+    glue,
+    purrr,
+    rlang (>= 1.0.6),
+    sensemakr,
+    tibble
+Suggests:
+    broom,
+    dplyr,
+    MASS,
+    testthat
+Encoding: UTF-8
 LazyData: true
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.2.1

--- a/R/adjust_coefficient.R
+++ b/R/adjust_coefficient.R
@@ -34,14 +34,14 @@ adjust_coef <-
       confounder_outcome_effect = confounder_outcome_effect
     )
     if (verbose) {
-      message_glue(
-        "The observed effect ({round(effect_observed, 2)}) ",
-        "is updated to {round(effect_adj, 2)} ",
-        "by a confounder with the following specifications:",
-        "\n  * estimated difference in scaled means: {exposure_confounder_effect}",
-        "\n  * estimated relationship between the unmeasured confounder and the ",
-        "outcome: {confounder_outcome_effect}\n"
-      )
+      message_cli(c(
+        "i" = "The observed effect ({round(effect_observed, 2)}) \\
+        is updated to {round(effect_adj, 2)} \\
+        by a confounder with the following specifications:",
+        "*" = "estimated difference in scaled means: {exposure_confounder_effect}",
+        "*" = "estimated relationship between the unmeasured confounder and the \\
+        outcome: {confounder_outcome_effect}"
+      ))
     }
     return(o)
   }
@@ -103,16 +103,19 @@ adjust_coef_with_binary <-
 
 
     if (verbose) {
-      message_glue(
-        "The observed effect ({round(effect_observed, 2)}) ",
-        "is updated to {round(o$effect_adjusted, 2)} ",
-        "by a confounder with the following specifications:",
-        "\n  * estimated prevalence of the unmeasured confounder ",
-        "in the exposed population: {round(exposed_confounder_prev, 2)}\n  * estimated prevalence of ",
-        "the unmeasured confounder in the unexposed population: {round(unexposed_confounder_prev, 2)}",
-        "\n  * estimated relationship between the unmeasured confounder and the ",
-        "outcome: {round(confounder_outcome_effect, 2)}\n"
-      )
+      message_cli(c(
+        "i" = "The observed effect ({round(effect_observed, 2)}) \\
+        is updated to {round(o$effect_adjusted, 2)} \\
+        by a confounder with the following specifications:",
+        "*" = "estimated prevalence of the unmeasured confounder \\
+        in the exposed population: {round(exposed_confounder_prev, 2)}",
+        "*" = "estimated prevalence of \\
+        the unmeasured confounder in the unexposed population: \\
+        {round(unexposed_confounder_prev, 2)}",
+
+        "*" = "estimated relationship between the unmeasured confounder and \\
+        the outcome: {round(confounder_outcome_effect, 2)}"
+      ))
     }
     return(o)
   }
@@ -152,14 +155,14 @@ adjust_rr <-
       confounder_outcome_effect = confounder_outcome_effect
     )
     if (verbose) {
-      message_glue(
-        "The observed effect (RR: {round(rr, 2)}) ",
-        "is updated to RR: {round(rr_adj, 2)} ",
-        "by a confounder with the following specifications:",
-        "\n  * estimated difference in scaled means: {exposure_confounder_effect}",
-        "\n  * estimated relationship (RR) between the unmeasured confounder and the ",
-        "outcome: {round(confounder_outcome_effect, 2)}\n"
-      )
+      message_cli(c(
+        "i" = "The observed effect (RR: {round(rr, 2)}) \\
+        is updated to RR: {round(rr_adj, 2)} \\
+        by a confounder with the following specifications:",
+        "*" = "estimated difference in scaled means: {exposure_confounder_effect}",
+        "*" = "estimated relationship (RR) between the unmeasured confounder \\
+        and the outcome: {round(confounder_outcome_effect, 2)}"
+      ))
     }
     return(o)
   }
@@ -209,17 +212,20 @@ adjust_hr <-
 
 
     if (verbose) {
-      message_glue(
-        "The observed effect ({output_type}: {round(o$rr_observed, 2)}) ",
-        "is updated to {output_type}: {round(o$rr_adjusted, 2)} ",
-        "by a confounder with the following specifications:",
-        "\n  * estimated difference in scaled means: {exposure_confounder_effect}",
-        "\n  * estimated relationship ({output_type}) between the unmeasured confounder and the ",
-        "outcome: {round(confounder_outcome_effect, 2)}\n",
-        "{ifelse(hr_correction, 'You opted to use the hazard ratio correction to convert your hazard ratios to approximate risk ratios.\nThis is a good idea if the outcome is common (>15%).',
-      '')}",
+      message_cli(c(
+        "i" = "The observed effect ({output_type}: {round(o$rr_observed, 2)}) \\
+        is updated to {output_type}: {round(o$rr_adjusted, 2)} \\
+        by a confounder with the following specifications:",
+        "*" = "estimated difference in scaled means: {exposure_confounder_effect}",
+        "*" = "estimated relationship ({output_type}) between the unmeasured \\
+        confounder and the outcome: {round(confounder_outcome_effect, 2)}"
+      ))
 
-      )
+      if (hr_correction) message_cli(c(
+        "i" = "You opted to use the hazard ratio correction to convert your \\
+        hazard ratios to approximate risk ratios. \\
+        This is a good idea if the outcome is common (>15%)"
+      ))
     }
 
     if (!hr_correction) {
@@ -273,16 +279,21 @@ adjust_or <-
     output_type <- ifelse(or_correction, 'RR', 'OR')
 
     if (verbose) {
-      message_glue(
-        "The observed effect ({output_type}: {round(o$rr_observed, 2)}) ",
-        "is updated to {output_type}: {round(o$rr_adjusted, 2)} ",
-        "by a confounder with the following specifications:",
-        "\n  * estimated difference in scaled means: {exposure_confounder_effect}",
-        "\n  * estimated relationship ({output_type}) between the unmeasured confounder and the ",
-        "outcome: {round(confounder_outcome_effect, 2)}\n",
-        "{ifelse(or_correction, 'You opted to use the odds ratio correction to convert your odds ratios to approximate risk ratios.\nThis is a good idea if the outcome is common (>15%).',
-      '')}"
-      )
+      message_cli(c(
+        "i" = "The observed effect ({output_type}: {round(o$rr_observed, 2)}) \\
+        is updated to {output_type}: {round(o$rr_adjusted, 2)} \\
+        by a confounder with the following specifications:",
+        "*" = "estimated difference in scaled means: {exposure_confounder_effect}",
+        "*" = "estimated relationship ({output_type}) between the unmeasured \\
+        confounder and the  outcome: {round(confounder_outcome_effect, 2)}"
+      ))
+
+
+      if (or_correction) message_cli(c(
+        "i" = "You opted to use the odds ratio correction to convert your \\
+        odds ratio to approximate risk ratios. \\
+        This is a good idea if the outcome is common (>15%)"
+      ))
     }
 
     if (!or_correction) {
@@ -334,16 +345,17 @@ adjust_rr_with_binary <-
       confounder_outcome_effect = confounder_outcome_effect
     )
     if (verbose) {
-      message_glue(
-        "The observed effect ({round(rr, 2)}) ",
-        "is updated to {round(rr_adj, 2)} ",
-        "by a confounder with the following specifications:",
-        "\n  * estimated prevalence of the unmeasured confounder ",
-        "in the exposed population: {round(exposed_confounder_prev, 2)}\n  * estimated prevalence of ",
-        "the unmeasured confounder in the unexposed population: {round(unexposed_confounder_prev, 2)}",
-        "\n  * estimated relationship between the unmeasured confounder and the ",
-        "outcome: {round(confounder_outcome_effect, 2)}\n"
-      )
+      message_cli(c(
+        "The observed effect ({round(rr, 2)}) \\
+        is updated to {round(rr_adj, 2)} \\
+        by a confounder with the following specifications:",
+        "*" = "estimated prevalence of the unmeasured confounder \\
+        in the exposed population: {round(exposed_confounder_prev, 2)}",
+        "*" = "estimated prevalence of the unmeasured confounder in the \\
+        unexposed population: {round(unexposed_confounder_prev, 2)}",
+        "*" = "estimated relationship between the unmeasured confounder and \\
+        the outcome: {round(confounder_outcome_effect, 2)}"
+      ))
     }
     return(o)
   }
@@ -394,18 +406,23 @@ adjust_hr_with_binary <-
     output_type <- ifelse(hr_correction, 'RR', 'HR')
 
     if (verbose) {
-      message_glue(
-        "The observed effect ({output_type}: {round(o$rr_observed, 2)}) ",
-        "is updated to {output_type}: {round(o$rr_adjusted, 2)} ",
-        "by a confounder with the following specifications:",
-        "\n  * estimated prevalence of the unmeasured confounder ",
-        "in the exposed population: {round(exposed_confounder_prev, 2)}\n  * estimated prevalence of ",
-        "the unmeasured confounder in the unexposed population: {round(unexposed_confounder_prev, 2)}",
-        "\n  * estimated relationship between the unmeasured confounder and the ",
-        "outcome: {round(confounder_outcome_effect, 2)}\n",
-        "{ifelse(hr_correction, 'You opted to use the hazard ratio correction to convert your hazard ratios to approximate risk ratios.\nThis is a good idea if the outcome is common (>15%).',
-      '')}"
-      )
+      message_cli(c(
+        "i" = "The observed effect ({output_type}: {round(o$rr_observed, 2)}) \\
+        is updated to {output_type}: {round(o$rr_adjusted, 2)} \\
+        by a confounder with the following specifications:",
+        "*" = "estimated prevalence of the unmeasured confounder \\
+        in the exposed population: {round(exposed_confounder_prev, 2)}",
+        "*" = "estimated prevalence of the unmeasured confounder in the \\
+        unexposed population: {round(unexposed_confounder_prev, 2)}",
+        "*" = "estimated relationship between the unmeasured confounder \\
+        and the outcome: {round(confounder_outcome_effect, 2)}"
+      ))
+
+      if (hr_correction) message_cli(c(
+        "i" = "You opted to use the hazard ratio correction to convert your \\
+        hazard ratios to approximate risk ratios. \\
+        This is a good idea if the outcome is common (>15%)"
+      ))
     }
 
     if (!hr_correction) {
@@ -464,18 +481,23 @@ adjust_or_with_binary <-
     output_type <- ifelse(or_correction, 'RR', 'OR')
 
     if (verbose) {
-      message_glue(
-        "The observed effect ({output_type}: {round(o$rr_observed, 2)}) ",
-        "is updated to {output_type}: {round(o$rr_adjusted, 2)} ",
-        "by a confounder with the following specifications:",
-        "\n  * estimated prevalence of the unmeasured confounder ",
-        "in the exposed population: {round(exposed_confounder_prev, 2)}\n  * estimated prevalence of ",
-        "the unmeasured confounder in the unexposed population: {round(unexposed_confounder_prev, 2)}",
-        "\n  * estimated relationship between the unmeasured confounder and the ",
-        "outcome: {round(confounder_outcome_effect, 2)}\n",
-        "{ifelse(or_correction, 'You opted to use the odds ratio correction to convert your odds ratios to approximate risk ratios.\nThis is a good idea if the outcome is common (>15%).',
-      '')}"
-      )
+      message_cli(c(
+        "*" = "The observed effect ({output_type}: {round(o$rr_observed, 2)}) \\
+        is updated to {output_type}: {round(o$rr_adjusted, 2)} \\
+        by a confounder with the following specifications:",
+        "*" = "estimated prevalence of the unmeasured confounder \\
+        in the exposed population: {round(exposed_confounder_prev, 2)}",
+        "*" = "estimated prevalence of the unmeasured confounder in the \\
+        unexposed population: {round(unexposed_confounder_prev, 2)}",
+        "*" = "estimated relationship between the unmeasured confounder and \\
+        the outcome: {round(confounder_outcome_effect, 2)}"
+      ))
+
+      if (or_correction) message_cli(c(
+        "i" = "You opted to use the odds ratio correction to convert your \\
+        odds ratios to approximate risk ratios. \\
+        This is a good idea if the outcome is common (>15%)"
+      ))
     }
 
     if (!or_correction) {

--- a/R/observed-bias-plot-helpers.R
+++ b/R/observed-bias-plot-helpers.R
@@ -91,11 +91,11 @@ check_drop_list <- function(l) {
   if (!is.null(l)) {
     n <- names(l)
     if (length(n) != length(l)) {
-      stop_glue("`drop_list` must be a named list.")
+      stop_cli("`drop_list` must be a named list.")
     }
     c <- purrr::map_lgl(l, is.character)
     if (!all(c)) {
-      stop_glue("`drop_list` must be a named list of character vectors.")
+      stop_cli("`drop_list` must be a named list of character vectors.")
     }
   }
 }

--- a/R/observed_covariate_e_value.R
+++ b/R/observed_covariate_e_value.R
@@ -14,8 +14,10 @@
 observed_covariate_e_value <- function(lb, ub, lb_adj, ub_adj, transform = NULL) {
   if (!is.null(transform)) {
     if (!transform %in% c("OR", "HR")) {
-      stop_glue("You input\n * `transform`: {transform}\n ",
-                "The only valid `transform` inputs are\n * 'HR'\n * 'OR'")
+      stop_cli(c(
+        "x" = "You input `transform`: {transform}\n ",
+        "i" = "The only valid `transform` inputs are 'HR' and 'OR'."
+      ))
     }
     if (transform == "OR") {
       lb <- sqrt(lb)

--- a/R/tip-helpers.R
+++ b/R/tip-helpers.R
@@ -1,16 +1,16 @@
 get_limiting_bound <- function(lb = NULL, ub = NULL) {
   if (is.null(lb) || is.null(ub)) {
-    stop(
-      "Please input a dataset `d` that contains your observed confidence interval. Be sure your column names match `lb_name` and `ub_name`",
-      call. = FALSE
-    )
+    stop_cli(c(
+      x = "Please input a dataset `d` that contains your observed confidence \\
+      interval. Be sure your column names match `lb_name` and `ub_name`"
+    ))
   }
   if (lb < 0 || ub < 0) {
-    stop_glue(
-      "You input: ({lb}, {ub})\n",
-      "We are expecting an odds ratio, hazard ratio, or risk ratio,\n",
-      "therefore the bounds should not be less than 0."
-    )
+    stop_cli(c(
+      "x" = "You input: ({lb}, {ub})\n",
+      "i" = "We are expecting an odds ratio, hazard ratio, or risk ratio; \\
+      therefore, the bounds should not be less than 0."
+    ))
   }
   if (lb > 1 && ub > 1) {
     return(lb)
@@ -18,16 +18,18 @@ get_limiting_bound <- function(lb = NULL, ub = NULL) {
   if (lb < 1 && ub < 1) {
     return(ub)
   }
-  stop_glue("You input: ({lb}, {ub})\n",
-            "Please input a significant result.")
+  stop_cli(c(
+    "x" = "You input: ({lb}, {ub})\n",
+    "*" = "Please input a significant result."
+  ))
 }
 
 get_lm_limiting_bound <- function(lb = NULL, ub = NULL) {
   if (is.null(lb) || is.null(ub)) {
-    stop(
-      "Please input a dataset `d` that contains your observed confidence interval. Be sure your column names match `lb_name` and `ub_name`",
-      call. = FALSE
-    )
+    stop_cli(c(
+      x = "Please input a dataset `d` that contains your observed confidence \\
+      interval. Be sure your column names match `lb_name` and `ub_name`"
+    ))
   }
 
   if (lb > 0 && ub > 0) {
@@ -36,25 +38,28 @@ get_lm_limiting_bound <- function(lb = NULL, ub = NULL) {
   if (lb < 0 && ub < 0) {
     return(ub)
   }
-  stop_glue("You input: ({lb}, {ub})\n",
-            "Please input a significant result.")
+
+  stop_cli(c(
+    "x" = "You input: ({lb}, {ub})\n",
+    "*" = "Please input a significant result."
+  ))
 }
 
 get_limiting_bound_adj <- function(b = NULL,
                                    lb = NULL,
                                    ub = NULL) {
   if (is.null(lb) || is.null(ub)) {
-    stop(
-      "Please input a data frame `d` that contains for your observed confidence interval.",
-      call. = FALSE
-    )
+    stop_cli(c(
+      x = "Please input a data frame `d` that contains for your observed \\
+      confidence interval."
+    ))
   }
   if (lb < 0 || ub < 0) {
-    stop_glue(
-      "You input: ({lb}, {ub})\n",
-      "We are expecting an odds ratio, hazard ratio, or risk ratio,\n",
-      "therefore the lower or upper bounds in `d` should not be less than 0."
-    )
+    stop_cli(c(
+      "x" = "You input: ({lb}, {ub})",
+      "i" = "We are expecting an odds ratio, hazard ratio, or risk ratio; \\
+      therefore, the lower or upper bounds in `d` should not be less than 0."
+    ))
   }
   if (b > 1) {
     return(lb)
@@ -66,21 +71,21 @@ get_limiting_bound_adj <- function(b = NULL,
 
 check_gamma <- function(gamma = NULL) {
   if (!is.null(gamma) && gamma < 0) {
-    stop_glue(
-      "You input:\n * `outcome_effect`: {gamma}\n",
-      "We are expecting a risk ratio, odds ratio, or hazard ratio,\n",
-      "therefore `outcome_effect` should not be less than 0."
-    )
+    stop_cli(c(
+      "x" = "You input:  `outcome_effect`: {gamma}",
+      "i" = "We are expecting a risk ratio, odds ratio, or hazard ratio; //
+      therefore `outcome_effect` should not be less than 0."
+    ))
   }
 }
 
 check_effect <- function(x) {
   if (x < 0) {
-    stop_glue(
-      "You input:\n * An observed effect of {x}\n",
-      "We are expecting a risk ratio, odds ratio, or hazard ratio,\n",
-      "therefore your effect should not be less than 0."
-    )
+    stop_cli(c(
+      "x" = "You input an observed effect of {x}",
+      "*" = "We are expecting a risk ratio, odds ratio, or hazard ratio; \\
+      therefore your effect should not be less than 0."
+    ))
   }
 }
 
@@ -89,107 +94,110 @@ check_effect <- function(x) {
 check_prevalences <- function(p0 = NULL, p1 = NULL) {
   if (is.null(p0)) {
     if (any(p1 < 0 | p1 > 1)) {
-      stop_glue(
-        "You input:\n * `exposed_confounder_prev`: {p1}\n",
-        "The prevalences entered must be between 0 and 1."
-      )
+      stop_cli(c(
+        "x" = "You input: `exposed_confounder_prev`: {p1}",
+        "i" = "The prevalences entered must be between 0 and 1."
+      ))
     }
   } else if (is.null(p1)) {
     if (any(p0 < 0 | p0 > 1)) {
-      stop_glue(
-        "You input:\n * `unexposed_confounder_prev`: {p0}\n",
-        "The prevalences entered must be between 0 and 1."
-      )
+
+      stop_cli(c(
+        "x" = "You input: `unexposed_confounder_prev`: {p0}",
+        "i" = "The prevalences entered must be between 0 and 1."
+      ))
     }
   } else if (any(p1 < 0 | p0 < 0 | p1 > 1 | p0 > 1)) {
-    stop_glue(
-      "You input:\n * `unexposed_confounder_prev`: {p0}\n * `exposed_confounder_prev`: {p1}\n",
-      "The prevalences entered must be between 0 and 1."
-    )
+    stop_cli(c(
+      "x" = "You input: `unexposed_confounder_prev`: {p0}, and \\
+      `exposed_confounder_prev`: {p1}",
+      "i" = "The prevalences entered must be between 0 and 1."
+    ))
   }
 }
 
 tip_gamma <- function(p0 = NULL,
                       p1 = NULL,
                       b = NULL) {
-  if (is.null(p1) || is.null(p0)) {
-    stop(
-      "Please input at least 2 of the following:\n * `unexposed_confounder_prev`\n * `exposed_confounder_prev`\n * `outcome_effect`",
-      call. = FALSE
-    )
-  }
 
   check_prevalences(p0, p1)
 
   gamma <- ((1 - p1) + b * (p0 - 1)) / (b * p0 - p1)
 
   if (gamma < 0) {
-    stop_glue(
-      "Given these prevalences:\n * `unexposed_confounder_prev`: {p0}\n * `exposed_confounder_prev`: {p1}\n",
-      "There does not exist an unmeasured confounder that could tip this.\n",
-      "Please specifiy a larger prevalence difference.\n",
-      "(ie: make `unexposed_confounder_prev` and `exposed_confounder_prev` farther apart)."
-    )
+    stop_cli(c(
+      "x" = "Given these prevalences (`unexposed_confounder_prev`: {p0}, \\
+      `exposed_confounder_prev`: {p1}), there does not exist an unmeasured \\
+      confounder that could tip this.",
+      "*" = "Please specifiy a larger prevalence difference \\
+      (ie: make `unexposed_confounder_prev` and `exposed_confounder_prev` \\
+      farther apart)."
+    ))
   }
   as.numeric(gamma)
 }
 
 check_r2 <- function(r2, exposure = FALSE, effect, se, df) {
   if (any(r2 < 0) | any(r2 > 1)) {
-    stop_glue("You input:\n {r2}\n",
-              "The partial R2 values entered must be between 0 and 1.")
+    stop_cli(c(
+      "x" = "You input `r2`: {r2}",
+      "i" = "The partial R2 values entered must be between 0 and 1."
+    ))
   }
   if (exposure) {
     if (any(r2 == 1)) {
-      stop_glue(
-        "You input:\n * `exposure_r2`: {r2}\n",
-        "This means 100% of the residual variation in the exposure ",
-        "is explained by the unmeasured confounder, meaning regardless ",
-        "of the unmeasured confounder - outcome relationship, this ",
-        "will be \"tipped\"."
-      )
+      stop_cli(c(
+        "x" = "You input `exposure_r2`: {r2}",
+        "i" = "This means 100% of the residual variation in the exposure \\
+        is explained by the unmeasured confounder, meaning regardless \\
+        of the unmeasured confounder - outcome relationship, this \\
+        will be tipped."
+      ))
     }
     limit <- sensemakr::partial_r2(effect / se, df)
     if (any(r2 < limit)) {
-      stop_glue(
-        "You input:\n * `exposure_r2`: {r2[r2 < limit]}\n",
-        "It is not possible to tip this result with any unmeasured ",
-        "confounder - outcome relationship. In fact, if your ",
-        "unmeasured confounder explained 100% of the residual ",
-        "variation in your outcome, the partial R2 for the unmeasured ",
-        "confounder - exposure relationship would have to be ",
-        "{round(limit, 3)} for the exposure - outcome relationship ",
-        "to be explained away."
-      )
+      stop_cli(c(
+        "x" = "You input `exposure_r2`: {r2[r2 < limit]}",
+        "i" = "It is not possible to tip this result with any unmeasured \\
+        confounder - outcome relationship. In fact, if your \\
+        unmeasured confounder explained 100% of the residual \\
+        variation in your outcome, the partial R2 for the unmeasured \\
+        confounder - exposure relationship would have to be \\
+        {round(limit, 3)} for the exposure - outcome relationship \\
+        to be explained away."
+      ))
     }
   }
 }
 tip_exposure_r2 <- function(effect, se, df, outcome_r2) {
   if (is.null(outcome_r2)) {
-    stop(
-      "Please input at least one of the following:\n * `exposure_r2`\n * `outcome_r2`",
-      call. = FALSE
-    )
+    stop_cli(c(
+      "x" = "Please input at least one of the following:",
+      "*" = "`exposure_r2`",
+      "*" = "`outcome_r2`"
+    ))
   }
   check_r2(outcome_r2)
 
   exposure_r2 <-
     effect ^ 2 / (effect ^ 2 + se ^ 2 * df * outcome_r2)
   if (any(exposure_r2 > 1)) {
-    stop_glue(
-      "Given the input:\n * `effect`: {effect}\n * `outcome_r2`: {outcome_r2[exposure_r2 > 1]}\n",
-      "There does not exist an unmeasured confounder that could tip this.\n",
-    )
+    stop_cli(c(
+      "x" = "Given the input `effect`: {effect}, \\
+      `outcome_r2`: {outcome_r2[exposure_r2 > 1]}, \\
+      there does not exist an unmeasured confounder that could tip this.",
+    ))
   }
   as.numeric(exposure_r2)
 }
 tip_exposure_r2_bound <-
   function(effect, se, df, outcome_r2, alpha) {
     if (is.null(outcome_r2)) {
-      stop(
-        "Please input at least one of the following:\n * `exposure_r2`\n * `outcome_r2`",
-        call. = FALSE
-      )
+      stop_cli(c(
+        "x" = "Please input at least one of the following:",
+        "*" = "`exposure_r2`",
+        "*" = "`outcome_r2`"
+      ))
     }
     check_r2(outcome_r2)
 
@@ -246,13 +254,13 @@ tip_exposure_r2_bound <-
       ) /
       (2 * (a ^ 4 + 2 * a ^ 2 * b ^ 2 * c * y + b ^ 4 * c ^ 2 * y ^ 2))
     if (exposure_r2 > 1) {
-      stop_glue(
-        "Given the inputs:\n * `effect`: {effect}\n * `se`: {se}\n * `df`: {df}\n",
-        "The observed confidence bounds would be {lb}, {ub}. Given the inputs:",
-        "\n * observed bounds: {lb}, {ub} \n * outcome_r2`: {outcome_r2}\n",
-        "There does not exist an unmeasured confounder that could tip",
-        "the bound.\n",
-      )
+      stop_cli(c(
+        "x" = "Given the inputs `effect`: {effect}, `se`: {se}, `df`: {df} \\
+        The observed confidence bounds would be {lb}, {ub}. Given the inputs \\
+        observed bounds: ({lb}, {ub}), `outcome_r2`: {outcome_r2}, \\
+        there does not exist an unmeasured confounder that could tip
+        the bound."
+      ))
     }
     as.numeric(exposure_r2)
   }
@@ -261,10 +269,11 @@ tip_exposure_r2_bound <-
 
 tip_outcome_r2 <- function(effect, se, df, exposure_r2) {
   if (is.null(exposure_r2)) {
-    stop(
-      "Please input at least one of the following:\n * `exposure_r2`\n * `outcome_r2`",
-      call. = FALSE
-    )
+    stop_cli(c(
+      "x" = "Please input at least one of the following:",
+      "*" = "`exposure_r2`",
+      "*" = "`outcome_r2`"
+    ))
   }
   check_r2(
     exposure_r2,
@@ -277,10 +286,11 @@ tip_outcome_r2 <- function(effect, se, df, exposure_r2) {
   outcome_r2 <-
     (effect ^ 2 - effect ^ 2 * exposure_r2) / (se ^ 2 * df * exposure_r2)
   if (any(outcome_r2 > 1)) {
-    stop_glue(
-      "Given the input:\n * `effect`: {effect}\n * `exposure_r2`: {exposure_r2[outcome_r2 > 1]}\n",
-      "There does not exist an unmeasured confounder that could tip this.\n",
-    )
+    stop_cli(c(
+      "x" = "Given the input `effect`: {effect}, \\
+      `exposure_r2`: {exposure_r2[outcome_r2 > 1]}, \\
+      there does not exist an unmeasured confounder that could tip this.",
+    ))
   }
   as.numeric(outcome_r2)
 }
@@ -288,10 +298,11 @@ tip_outcome_r2 <- function(effect, se, df, exposure_r2) {
 tip_outcome_r2_bound <-
   function(effect, se, df, exposure_r2, alpha) {
     if (is.null(exposure_r2)) {
-      stop(
-        "Please input at least one of the following:\n * `exposure_r2`\n * `outcome_r2`",
-        call. = FALSE
-      )
+      stop_cli(c(
+        "x" = "Please input at least one of the following:",
+        "*" = "`exposure_r2`",
+        "*" = "`outcome_r2`"
+      ))
     }
     check_r2(
       exposure_r2,
@@ -350,13 +361,13 @@ tip_outcome_r2_bound <-
                                   2 * c * y ^
                                   2 + d ^ 4 - 2 * d ^ 2 * y + y ^ 2))
     if (outcome_r2 > 1) {
-      stop_glue(
-        "Given the inputs:\n * `effect`: {effect}\n * `se`: {se}\n * `df`: {df}\n",
-        "The observed confidence bounds would be {lb}, {ub}. Given the inputs:",
-        "\n * observed bounds: {lb}, {ub} \n * exposure_r2`: {exposure_r2}\n",
-        "There does not exist an unmeasured confounder that could tip",
-        "the bound.\n",
-      )
+      stop_cli(c(
+        "x" = "Given the inputs `effect`: {effect}, `se`: {se}, `df`: {df}, \\
+        The observed confidence bounds would be {lb}, {ub}. Given the inputs \\
+        observed bounds: ({lb}, {ub}), `exposure_r2`: {exposure_r2}, \\
+        there does not exist an unmeasured confounder that could tip \\
+        the bound."
+      ))
     }
     as.numeric(outcome_r2)
   }
@@ -366,23 +377,17 @@ tip_outcome_r2_bound <-
 tip_p0 <- function(p1 = NULL,
                    gamma = NULL,
                    b = NULL) {
-  if (is.null(p1) || is.null(gamma)) {
-    stop(
-      "Please input at least 2 of the following:\n * `unexposed_confounder_prev`\n * `exposed_confounder_prev`\n * `outcome_effect`.",
-      call. = FALSE
-    )
-  }
-
   check_prevalences(p1 = p1)
   check_gamma(gamma)
 
   p0 <- (p1 * (gamma - 1) - b + 1) / (b * (gamma - 1))
 
   if (p0 > 1 | p0 < 0) {
-    stop_glue(
-      "Given these parameters:\n * `exposed_confounder_prev`: {p1}\n * `outcome_effect`: {gamma}\n",
-      "There does not exist an unmeasured confounder that could tip this."
-    )
+    stop_cli(c(
+      "x" = "Given these parameters (`exposed_confounder_prev`: {p1}, \\
+      `outcome_effect`: {gamma}), \\
+      there does not exist an unmeasured confounder that could tip this."
+    ))
   }
   as.numeric(p0)
 }
@@ -391,23 +396,17 @@ tip_p0 <- function(p1 = NULL,
 tip_p1 <- function(p0 = NULL,
                    gamma = NULL,
                    b = NULL) {
-  if (is.null(p0) || is.null(gamma)) {
-    stop(
-      "Please input at least 2 of the following:\n * `unexposed_confounder_prev`\n * `exposed_confounder_prev`\n * `outcome_effect`.",
-      call. = FALSE
-    )
-  }
-
   check_prevalences(p0 = p0)
   check_gamma(gamma)
 
   p1 <- ((b - 1) / (gamma - 1)) + b * p0
 
   if (p1 > 1 | p1 < 0) {
-    stop_glue(
-      "Given these parameters:\n * `unexposed_confounder_prev`: {p0}\n * `outcome_effect`: {gamma}\n",
-      "There does not exist an unmeasured confounder that could tip this."
-    )
+    stop_cli(c(
+      "x" = "Given these parameters (`unexposed_confounder_prev`: {p0}, \\
+      * `outcome_effect`: {gamma}), \\
+      there does not exist an unmeasured confounder that could tip this."
+    ))
   }
   as.numeric(p1)
 }
@@ -420,9 +419,9 @@ tip_n <- function(p0, p1, gamma, b) {
     -log(b) / (log(gamma * p0 + (1 - p0)) - log(gamma * p1 + (1 - p1)))
   if (n < 0) {
     n <- 0
-    warning_glue("The observed effect {b} would not tip with the unmeasured confounder given.")
+    warning_cli("The observed effect {b} would not tip with the unmeasured confounder given.")
   } else if (n < 1) {
-    warning_glue("The observed effect {b} would tip with < 1 of the given unmeasured confounders.")
+    warning_cli("The observed effect {b} would tip with < 1 of the given unmeasured confounders.")
   }
 
   as.numeric(n)

--- a/R/tip-helpers.R
+++ b/R/tip-helpers.R
@@ -185,7 +185,7 @@ tip_exposure_r2 <- function(effect, se, df, outcome_r2) {
     stop_cli(c(
       "x" = "Given the input `effect`: {effect}, \\
       `outcome_r2`: {outcome_r2[exposure_r2 > 1]}, \\
-      there does not exist an unmeasured confounder that could tip this.",
+      there does not exist an unmeasured confounder that could tip this."
     ))
   }
   as.numeric(exposure_r2)
@@ -289,7 +289,7 @@ tip_outcome_r2 <- function(effect, se, df, exposure_r2) {
     stop_cli(c(
       "x" = "Given the input `effect`: {effect}, \\
       `exposure_r2`: {exposure_r2[outcome_r2 > 1]}, \\
-      there does not exist an unmeasured confounder that could tip this.",
+      there does not exist an unmeasured confounder that could tip this."
     ))
   }
   as.numeric(outcome_r2)

--- a/R/tip.R
+++ b/R/tip.R
@@ -47,6 +47,12 @@
 tip <- function(effect_observed, exposure_confounder_effect = NULL, confounder_outcome_effect = NULL,
                 verbose = getOption("tipr.verbose", TRUE), correction_factor = "none") {
 
+  check_arguments(
+    "tip()",
+    exposure_confounder_effect,
+    confounder_outcome_effect
+  )
+
   exposure_confounder_effect <- exposure_confounder_effect %||% list(NULL)
   confounder_outcome_effect <- confounder_outcome_effect %||% list(NULL)
 
@@ -99,11 +105,12 @@ tip_one <- function(b, exposure_confounder_effect, confounder_outcome_effect, ve
         confounder_outcome_effects <- confounder_outcome_effect
       }
 
-      warning_glue(
-        "The observed effect {b} would not tip with the unmeasured confounder given:",
-        "\n  * `exposure_confounder_effect`: {exposure_confounder_effects}",
-        "\n  * `confounder_outcome_effect`: {confounder_outcome_effects}\n\n"
-      )
+      warning_cli(c(
+        "!" = "The observed effect {b} would not tip with the unmeasured \\
+        confounder given:",
+        "*" = "`exposure_confounder_effect`: {exposure_confounder_effects}",
+        "*" = "`confounder_outcome_effect`: {confounder_outcome_effects}"
+      ))
       n_unmeasured_confounders <- max(0, n_unmeasured_confounders)
     }
     too_small <-
@@ -114,11 +121,12 @@ tip_one <- function(b, exposure_confounder_effect, confounder_outcome_effect, ve
         ifelse(length(confounder_outcome_effect) > 1,
                confounder_outcome_effect[too_small],
                confounder_outcome_effect)
-      warning_glue(
-        "The observed effect {b} would tip with < 1 of the given unmeasured confounders:",
-        "\n  * `exposure_confounder_effect`: {exposure_confounder_effects}",
-        "\n  * `confounder_outcome_effect`: {confounder_outcome_effects}\n\n"
-      )
+      warning_cli(c(
+        "!" = "The observed effect {b} would tip with < 1 of the given \\
+        unmeasured confounders:",
+        "*" = "`exposure_confounder_effect`: {exposure_confounder_effects}",
+        "*" = "`confounder_outcome_effect`: {confounder_outcome_effects}"
+      ))
     }
   }
   o <- tibble::tibble(
@@ -131,53 +139,63 @@ tip_one <- function(b, exposure_confounder_effect, confounder_outcome_effect, ve
   if (verbose) {
     if (all(o$n_unmeasured_confounders == 0)) {
       o_notip <- o[o$n_unmeasured_confounders == 0,]
-      message_glue(
-        "The observed effect ({round(o_notip$effect_observed, 2)}) ",
-        "cannot be tipped by an unmeasured confounder\nwith the ",
-        "following specifications:",
-        "\n  * estimated difference in scaled means between the ",
-        "unmeasured confounder\n     in the exposed population and ",
-        "unexposed population: {round(o_notip$exposure_confounder_effect, 2)}",
-        "\n  * estimated relationship between the unmeasured confounder and the ",
-        "outcome: {round(o_notip$confounder_outcome_effect, 2)}\n\n{correction}"
-      )
+      message_cli(c(
+        "i" = "The observed effect ({round(o_notip$effect_observed, 2)}) \\
+        cannot be tipped by an unmeasured confounder\nwith the \\
+        following specifications:",
+        "*" = "estimated difference in scaled means between the \\
+        unmeasured confounder\n     in the exposed population and \\
+        unexposed population: {round(o_notip$exposure_confounder_effect, 2)}",
+        "*" = "estimated relationship between the unmeasured confounder and \\
+        the outcome: {round(o_notip$confounder_outcome_effect, 2)}"
+      ))
+
+      if (correction != "") message_cli(c("i" = correction))
+
     } else if (any(o$n_unmeasured_confounders == 0)) {
       o_notip <- o[o$n_unmeasured_confounders == 0,]
-      message_glue(
-        "The observed effect ({round(o_notip$effect_observed, 2)}) ",
-        "cannot be tipped by an unmeasured confounder\nwith the ",
-        "following specifications:",
-        "\n  * estimated difference in scaled means between the ",
-        "unmeasured confounder\n     in the exposed population and ",
-        "unexposed population: {round(o_notip$exposure_confounder_effect, 2)}",
-        "\n  * estimated relationship between the unmeasured confounder and the ",
-        "outcome: {round(o_notip$confounder_outcome_effect, 2)}\n\n{correction}"
-      )
+      message_cli(c(
+        "i" = "The observed effect ({round(o_notip$effect_observed, 2)}) \\
+        cannot be tipped by an unmeasured confounder with the \\
+        following specifications:",
+        "*" = "estimated difference in scaled means between the \\
+        unmeasured confounder in the exposed population and \\
+        unexposed population: {round(o_notip$exposure_confounder_effect, 2)}",
+        "*" = "estimated relationship between the unmeasured confounder and \\
+        the outcome: {round(o_notip$confounder_outcome_effect, 2)}"
+      ))
+
+      if (correction != "") message_cli(c("i" = correction))
 
       o_tip <- o[o$n_unmeasured_confounders != 0,]
-      message_glue(
-        "The observed effect ({round(o_tip$effect_observed, 2)}) WOULD ",
-        "be tipped by {round(o$n_unmeasured_confounders)} ",
-        "unmeasured confounder{ifelse(o_tip$n_unmeasured_confounders > 1, 's', '')}\n",
-        "with the following specifications:",
-        "\n  * estimated difference in scaled means between the ",
-        "unmeasured confounder\n    in the exposed population and ",
-        "unexposed population: {round(o_tip$exposure_confounder_effect, 2)}",
-        "\n  * estimated relationship between the unmeasured confounder and the ",
-        "outcome: {round(o_tip$confounder_outcome_effect, 2)}\n\n{correction}"
-      )
+      message_cli(c(
+        "i" = "The observed effect ({round(o_tip$effect_observed, 2)}) WOULD \\
+        be tipped by {round(o$n_unmeasured_confounders)} \\
+        unmeasured confounder{ifelse(o_tip$n_unmeasured_confounders > 1, 's', '')} \\
+        with the following specifications:",
+        "*" = "estimated difference in scaled means between the \\
+        unmeasured confounder in the exposed population and \\
+        unexposed population: {round(o_tip$exposure_confounder_effect, 2)}",
+        "*" = "estimated relationship between the unmeasured confounder and \\
+        the outcome: {round(o_tip$confounder_outcome_effect, 2)}"
+      ))
+
+      if (correction != "") message_cli(c("i" = correction))
+
     } else {
-      message_glue(
-        "The observed effect ({round(o$effect_observed, 2)}) WOULD ",
-        "be tipped by {round(o$n_unmeasured_confounders)} ",
-        "unmeasured confounder{ifelse(o$n_unmeasured_confounders > 1, 's', '')}\n",
-        "with the following specifications:",
-        "\n  * estimated difference in scaled means between the ",
-        "unmeasured confounder\n    in the exposed population and ",
-        "unexposed population: {round(o$exposure_confounder_effect, 2)}",
-        "\n  * estimated relationship between the unmeasured confounder and the ",
-        "outcome: {round(o$confounder_outcome_effect, 2)}\n\n{correction}"
-      )
+      message_cli(c(
+        "i" = "The observed effect ({round(o$effect_observed, 2)}) WOULD \\
+        be tipped by {round(o$n_unmeasured_confounders)} \\
+        unmeasured confounder{ifelse(o$n_unmeasured_confounders > 1, 's', '')} \\
+        with the following specifications:",
+        "*" = "estimated difference in scaled means between the \\
+        unmeasured confounder in the exposed population and \\
+        unexposed population: {round(o$exposure_confounder_effect, 2)}",
+        "*" = "estimated relationship between the unmeasured confounder and \\
+        the outcome: {round(o$confounder_outcome_effect, 2)}"
+      ))
+
+      if (correction != "") message_cli(c("i" = correction))
     }
   }
   o
@@ -213,7 +231,18 @@ tip_one <- function(b, exposure_confounder_effect, confounder_outcome_effect, ve
 #'
 #' @export
 tip_rr <- function(effect_observed, exposure_confounder_effect = NULL, confounder_outcome_effect = NULL, verbose = getOption("tipr.verbose", TRUE)) {
-  tip(effect_observed, exposure_confounder_effect = exposure_confounder_effect, confounder_outcome_effect = confounder_outcome_effect, verbose = verbose)
+  check_arguments(
+    "tip_rr()",
+    exposure_confounder_effect,
+    confounder_outcome_effect
+  )
+
+  tip(
+    effect_observed,
+    exposure_confounder_effect = exposure_confounder_effect,
+    confounder_outcome_effect = confounder_outcome_effect,
+    verbose = verbose
+  )
 }
 
 
@@ -251,8 +280,19 @@ tip_rr <- function(effect_observed, exposure_confounder_effect = NULL, confounde
 #'
 #' @export
 tip_hr <- function(effect_observed, exposure_confounder_effect = NULL, confounder_outcome_effect = NULL, verbose = getOption("tipr.verbose", TRUE), hr_correction = FALSE) {
+  check_arguments(
+    "tip_hr()",
+    exposure_confounder_effect,
+    confounder_outcome_effect
+  )
   correction_factor <- ifelse(hr_correction, "hr", "none")
-  tip(effect_observed, exposure_confounder_effect = exposure_confounder_effect, confounder_outcome_effect = confounder_outcome_effect, verbose = verbose, correction_factor = correction_factor)
+  tip(
+    effect_observed,
+    exposure_confounder_effect = exposure_confounder_effect,
+    confounder_outcome_effect = confounder_outcome_effect,
+    verbose = verbose,
+    correction_factor = correction_factor
+  )
 }
 
 #' Tip an observed odds ratio with a normally distributed confounder.
@@ -298,8 +338,21 @@ tip_hr <- function(effect_observed, exposure_confounder_effect = NULL, confounde
 #'}
 #' @export
 tip_or <- function(effect_observed, exposure_confounder_effect = NULL, confounder_outcome_effect = NULL, verbose = getOption("tipr.verbose", TRUE), or_correction = FALSE) {
+  check_arguments(
+    "tip_or()",
+    exposure_confounder_effect,
+    confounder_outcome_effect
+  )
+
   correction_factor <- ifelse(or_correction, "or", "none")
-  tip(effect_observed, exposure_confounder_effect = exposure_confounder_effect, confounder_outcome_effect = confounder_outcome_effect, verbose = verbose, correction_factor = correction_factor)
+
+  tip(
+    effect_observed,
+    exposure_confounder_effect = exposure_confounder_effect,
+    confounder_outcome_effect = confounder_outcome_effect,
+    verbose = verbose,
+    correction_factor = correction_factor
+  )
 }
 
 #' @rdname tip_rr

--- a/R/tip_coef.R
+++ b/R/tip_coef.R
@@ -38,6 +38,11 @@
 #'}
 #' @export
 tip_coef <- function(effect_observed, exposure_confounder_effect = NULL, confounder_outcome_effect = NULL, verbose = getOption("tipr.verbose", TRUE)) {
+  check_arguments(
+    "tip_coef()",
+    exposure_confounder_effect,
+    confounder_outcome_effect
+  )
 
   o <- purrr::map(
     effect_observed,
@@ -72,11 +77,11 @@ tip_coef_one <- function(b, exposure_confounder_effect, confounder_outcome_effec
         confounder_outcome_effects <- confounder_outcome_effect
       }
 
-      warning_glue(
-        "The observed effect {b} would not tip with the unmeasured confounder given:",
-        "\n  * `exposure_confounder_effect`: {exposure_confounder_effects}",
-        "\n  * `confounder_outcome_effect`: {confounder_outcome_effects}\n\n"
-      )
+      warning_cli(c(
+        "!" = "The observed effect {b} would not tip with the unmeasured confounder given:",
+        "*" = "`exposure_confounder_effect`: {exposure_confounder_effects}",
+        "*" = "`confounder_outcome_effect`: {confounder_outcome_effects}\n\n"
+      ))
       n_unmeasured_confounders <- max(0, n_unmeasured_confounders)
     }
     too_small <-
@@ -87,11 +92,11 @@ tip_coef_one <- function(b, exposure_confounder_effect, confounder_outcome_effec
         ifelse(length(confounder_outcome_effect) > 1,
                confounder_outcome_effect[too_small],
                confounder_outcome_effect)
-      warning_glue(
-        "The observed effect {b} would tip with < 1 of the given unmeasured confounders:",
-        "\n  * `exposure_confounder_effect`: {exposure_confounder_effects}",
-        "\n  * `confounder_outcome_effect`: {confounder_outcome_effects}\n\n"
-      )
+      warning_cli(c(
+        "!" = "The observed effect {b} would tip with < 1 of the given unmeasured confounders:",
+        "*" = "`exposure_confounder_effect`: {exposure_confounder_effects}",
+        "*" = "`confounder_outcome_effect`: {confounder_outcome_effects}\n\n"
+      ))
     }
   }
   o <- tibble::tibble(
@@ -103,53 +108,53 @@ tip_coef_one <- function(b, exposure_confounder_effect, confounder_outcome_effec
   if (verbose) {
     if (all(o$n_unmeasured_confounders == 0)) {
       o_notip <- o[o$n_unmeasured_confounders == 0,]
-      message_glue(
-        "The observed effect ({round(o_notip$effect_observed, 2)}) ",
-        "cannot be tipped by an unmeasured confounder\nwith the ",
-        "following specifications:",
-        "\n  * estimated difference in scaled means between the ",
-        "unmeasured confounder\n     in the exposed population and ",
-        "unexposed population: {round(o_notip$exposure_confounder_effect, 2)}",
-        "\n  * estimated relationship between the unmeasured confounder and the ",
-        "outcome: {round(o_notip$confounder_outcome_effect, 2)}\n\n"
-      )
+      message_cli(c(
+        "i" = "The observed effect ({round(o_notip$effect_observed, 2)}) \\
+        cannot be tipped by an unmeasured confounder with the \\
+        following specifications:",
+        "*" = "estimated difference in scaled means between the \\
+        unmeasured confounder in the exposed population and \\
+        unexposed population: {round(o_notip$exposure_confounder_effect, 2)}",
+        "*" = "estimated relationship between the unmeasured confounder and \\
+        the outcome: {round(o_notip$confounder_outcome_effect, 2)}"
+      ))
     } else if (any(o$n_unmeasured_confounders == 0)) {
       o_notip <- o[o$n_unmeasured_confounders == 0,]
-      message_glue(
-        "The observed effect ({round(o_notip$effect_observed, 2)}) ",
-        "cannot be tipped by an unmeasured confounder\nwith the ",
-        "following specifications:",
-        "\n  * estimated difference in scaled means between the ",
-        "unmeasured confounder\n     in the exposed population and ",
-        "unexposed population: {round(o_notip$exposure_confounder_effect, 2)}",
-        "\n  * estimated relationship between the unmeasured confounder and the ",
-        "outcome: {round(o_notip$confounder_outcome_effect, 2)}\n\n"
-      )
+      message_cli(c(
+        "i" = "The observed effect ({round(o_notip$effect_observed, 2)}) \\
+        cannot be tipped by an unmeasured confounder with the \\
+        following specifications:",
+        "*" = "estimated difference in scaled means between the \\
+        unmeasured confounder in the exposed population and \\
+        unexposed population: {round(o_notip$exposure_confounder_effect, 2)}",
+        "*" = "estimated relationship between the unmeasured confounder and \\
+        the outcome: {round(o_notip$confounder_outcome_effect, 2)}"
+      ))
 
       o_tip <- o[o$n_unmeasured_confounders != 0,]
-      message_glue(
-        "The observed effect ({round(o_tip$effect_observed, 2)}) WOULD ",
-        "be tipped by {round(o$n_unmeasured_confounders)} ",
-        "unmeasured confounder{ifelse(o_tip$n_unmeasured_confounders > 1, 's', '')}\n",
-        "with the following specifications:",
-        "\n  * estimated difference in scaled means between the ",
-        "unmeasured confounder\n    in the exposed population and ",
-        "unexposed population: {round(o_tip$exposure_confounder_effect, 2)}",
-        "\n  * estimated relationship between the unmeasured confounder and the ",
-        "outcome: {round(o_tip$confounder_outcome_effect, 2)}\n\n"
-      )
+      message_cli(c(
+        "i" = "The observed effect ({round(o_tip$effect_observed, 2)}) WOULD \\
+        be tipped by {round(o$n_unmeasured_confounders)} \\
+        unmeasured confounder{ifelse(o_tip$n_unmeasured_confounders > 1, 's', '')}\n \\
+        with the following specifications:",
+        "*" = "estimated difference in scaled means between the \\
+        unmeasured confounder in the exposed population and \\
+        unexposed population: {round(o_tip$exposure_confounder_effect, 2)}",
+        "*" = "estimated relationship between the unmeasured confounder and \\
+        the outcome: {round(o_tip$confounder_outcome_effect, 2)}"
+      ))
     } else {
-      message_glue(
-        "The observed effect ({round(o$effect_observed, 2)}) WOULD ",
-        "be tipped by {round(o$n_unmeasured_confounders)} ",
-        "unmeasured confounder{ifelse(o$n_unmeasured_confounders > 1, 's', '')}\n",
-        "with the following specifications:",
-        "\n  * estimated difference in scaled means between the ",
-        "unmeasured confounder\n    in the exposed population and ",
-        "unexposed population: {round(o$exposure_confounder_effect, 2)}",
-        "\n  * estimated relationship between the unmeasured confounder and the ",
-        "outcome: {round(o$confounder_outcome_effect, 2)}\n\n"
-      )
+      message_cli(c(
+        "i" = "The observed effect ({round(o$effect_observed, 2)}) WOULD \\
+        be tipped by {round(o$n_unmeasured_confounders)} \\
+        unmeasured confounder{ifelse(o$n_unmeasured_confounders > 1, 's', '')}\n \\
+        with the following specifications:",
+        "*" = "estimated difference in scaled means between the \\
+        unmeasured confounder\n    in the exposed population and \\
+        unexposed population: {round(o$exposure_confounder_effect, 2)}",
+        "*" = "estimated relationship between the unmeasured confounder \\
+        and the outcome: {round(o$confounder_outcome_effect, 2)}"
+      ))
     }
   }
   o

--- a/R/utils.R
+++ b/R/utils.R
@@ -54,7 +54,7 @@ check_arguments <- function(what, ...) {
   if (not_enough(args)) {
     stop_cli(c(
       "x" = "`{what}` requires at least {count_required_args(args)} of the \\
-      following arguments specifed:",
+      following arguments specified:",
       bullets(arg_names)
     ))
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -8,32 +8,69 @@
 #' @usage lhs \%>\% rhs
 NULL
 
-stop_glue <- function(..., .sep = "", .envir = parent.frame(),
-                      call. = FALSE, .domain = NULL) {
-  stop(
-    glue::glue(..., .sep = .sep, .envir = .envir),
-    call. = call., domain = .domain
+stop_cli <- function(message, ..., .envir = parent.frame()) {
+  cli::cli_abort(
+    message,
+    ...,
+    .envir = .envir
   )
 }
 
-warning_glue <- function(..., .sep = "", .envir = parent.frame(),
-                         call. = FALSE, .domain = NULL) {
-  warning(
-    glue::glue(..., .sep = .sep, .envir = .envir),
-    call. = call., domain = .domain
+warning_cli <- function(message, ..., .envir = parent.frame()) {
+  cli::cli_warn(
+    message,
+    ...,
+    .envir = .envir
   )
 }
 
-message_glue <- function(..., .sep = "", .envir = parent.frame(),
-                         .domain = NULL) {
-  message(
-    glue::glue(..., .sep = .sep, .envir = .envir),
-    domain = .domain
+message_cli <- function(message, ..., .envir = parent.frame()) {
+  cli::cli_inform(
+    message,
+    ...,
+    .envir = .envir
   )
 }
 
-`%||%` <- function (x, y) {
+bullets <- function(..., code = TRUE) {
+  x <- c(...)
+  if (code) x <- glue::glue("`{x}`")
+  names(x) <- rep("*", length(x))
+
+  x
+}
+
+`%||%` <- function(x, y) {
   if (is.null(x)) {
     y
   } else x
 }
+
+check_arguments <- function(what, ...) {
+  arg_quos <- rlang::enquos(...)
+  arg_names <- purrr::map_chr(arg_quos, rlang::quo_text)
+  args <- list(...)
+
+  if (not_enough(args)) {
+    stop_cli(c(
+      "x" = "`{what}` requires at least {count_required_args(args)} of the \\
+      following arguments specifed:",
+      bullets(arg_names)
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+count_required_args <- function(.args) {
+  length(.args) - 1
+}
+
+count_non_null_args <- function(.args) {
+  sum(purrr::map_lgl(.args, purrr::negate(is.null)))
+}
+
+not_enough <- function(.args) {
+  count_non_null_args(.args) < count_required_args(.args)
+}
+

--- a/tests/testthat/test-tip-helpers.R
+++ b/tests/testthat/test-tip-helpers.R
@@ -39,7 +39,6 @@ test_that("get_limiting_bound() gives correct bound", {
 })
 
 test_that("tip_gamma() errors when necessary", {
-  expect_error(tip_gamma(), "Please input at least 2 of the following")
   expect_error(
     tip_gamma(p0 = -1, p1 = 1),
     "The prevalences entered must be between 0 and 1"
@@ -56,6 +55,6 @@ test_that("tip_gamma() returns correct result", {
   expect_identical(tip_gamma(p0 = 1, p1 = 0, b = 1.2), 1 / 1.2)
   expect_error(
     tip_gamma(p0 = .5, p1 = .2, b = 5),
-    "There does not exist an unmeasured confounder"
+    "there does not exist an unmeasured"
   )
 })


### PR DESCRIPTION
Closes #14 

This PR also updates to use cli and rlang for errors, which were already implicit dependencies via purrr. 

``` r
library(tipr)
tip_coef(1)
#> Error in `check_arguments()` at tipr/R/tip_coef.R:41:2:
#> ✖ `tip_coef()` requires at least 1 of the following arguments specified:
#> • `exposure_confounder_effect`
#> • `confounder_outcome_effect`

#> Backtrace:
#>     ▆
#>  1. └─tipr::tip_coef(1)
#>  2.   └─tipr:::check_arguments("tip_coef()", exposure_confounder_effect, confounder_outcome_effect) at tipr/R/tip_coef.R:41:2
#>  3.     └─tipr:::stop_cli(...) at tipr/R/utils.R:55:4
#>  4.       └─cli::cli_abort(message, ..., .envir = .envir) at tipr/R/utils.R:12:2
#>  5.         └─rlang::abort(...)
```

<sup>Created on 2022-11-25 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>